### PR TITLE
Adds + operator for `String?`

### DIFF
--- a/Swiftification/String.swift
+++ b/Swiftification/String.swift
@@ -52,5 +52,11 @@ public extension String {
         }
         return result
     }
-    
+
+}
+
+public func +(lhs: String?, rhs: String?) -> String? {
+    guard let lhs = lhs else { return rhs }
+    guard let rhs = rhs else { return lhs }
+    return lhs + rhs
 }

--- a/SwiftificationTests/StringTests.swift
+++ b/SwiftificationTests/StringTests.swift
@@ -87,4 +87,21 @@ class StringTests: XCTestCase {
         XCTAssertNil(str[safe: str.startIndex.advancedBy(5, limit: str.endIndex)])
     }
     
+    func testAppendAndPrependOptionalString() {
+        let str1: String? = "Hi"
+        let str2: String? = " Bob "
+        let strNil: String? = nil
+        
+        let prependString1On2 = str1 + str2 // "Hi Bob "
+        let appendString1On2 = str2 + str1 // " Bob Hi"
+        let onlyString1 = str1 + strNil // "Hi"
+        let onlyString1Append = strNil + str1 // "Hi"
+        
+        XCTAssertEqual(prependString1On2, "Hi Bob ")
+        XCTAssertEqual(appendString1On2, " Bob Hi")
+        XCTAssertEqual(onlyString1, "Hi")
+        XCTAssertEqual(onlyString1Append, "Hi")
+        
+    }
+    
 }

--- a/SwiftificationTests/StringTests.swift
+++ b/SwiftificationTests/StringTests.swift
@@ -91,16 +91,16 @@ class StringTests: XCTestCase {
         let str1: String? = "Hi"
         let str2: String? = " Bob "
         let strNil: String? = nil
+        let nonNilString = "I'm not Nil!"
+        XCTAssertEqual(str1 + str2, "Hi Bob ")
+        XCTAssertEqual(str2 + str1, " Bob Hi")
+        XCTAssertEqual(str1 + strNil, "Hi")
+        XCTAssertEqual(strNil + str1, "Hi")
+        XCTAssertEqual(nonNilString + str1, "I'm not Nil!Hi")
+        XCTAssertEqual(str1 + nonNilString, "HiI'm not Nil!")
+        XCTAssertEqual(strNil + nonNilString, "I'm not Nil!")
+        XCTAssertEqual(nonNilString + strNil, "I'm not Nil!")
         
-        let prependString1On2 = str1 + str2 // "Hi Bob "
-        let appendString1On2 = str2 + str1 // " Bob Hi"
-        let onlyString1 = str1 + strNil // "Hi"
-        let onlyString1Append = strNil + str1 // "Hi"
-        
-        XCTAssertEqual(prependString1On2, "Hi Bob ")
-        XCTAssertEqual(appendString1On2, " Bob Hi")
-        XCTAssertEqual(onlyString1, "Hi")
-        XCTAssertEqual(onlyString1Append, "Hi")
         
     }
     


### PR DESCRIPTION
Per @nickmshelley's suggestion, this will add the `+` operator to `String?`s.  Fixes #28 